### PR TITLE
Fix null property error, optimize camera config

### DIFF
--- a/backend/app/routers/cameras.py
+++ b/backend/app/routers/cameras.py
@@ -90,11 +90,11 @@ async def discover_cameras(
 async def get_cameras(
     status_filter: Optional[str] = None,
     active_only: bool = False,
-    current_user: CurrentUser = Depends(require_admin_or_above)
+    current_user: CurrentUser = Depends(require_super_admin)
 ):
     """
     Get list of all cameras with optional filtering
-    (Admin+ only)
+    (Super Admin only)
     """
     try:
         db_manager = DatabaseManager()
@@ -165,11 +165,11 @@ async def get_cameras(
 @router.get("/{camera_id}", response_model=CameraInfo)
 async def get_camera(
     camera_id: int,
-    current_user: CurrentUser = Depends(require_admin_or_above)
+    current_user: CurrentUser = Depends(require_super_admin)
 ):
     """
     Get detailed information about a specific camera
-    (Admin+ only)
+    (Super Admin only)
     """
     try:
         db_manager = DatabaseManager()
@@ -510,11 +510,11 @@ async def delete_camera(
 @router.get("/{camera_id}/status", response_model=CameraStatusResponse)
 async def get_camera_status(
     camera_id: int,
-    current_user: CurrentUser = Depends(require_admin_or_above)
+    current_user: CurrentUser = Depends(require_super_admin)
 ):
     """
     Get real-time status of a camera
-    (Admin+ only)
+    (Super Admin only)
     """
     try:
         db_manager = DatabaseManager()
@@ -594,11 +594,11 @@ async def create_tripwire(
 @router.get("/{camera_id}/tripwires", response_model=List[Tripwire])
 async def get_camera_tripwires(
     camera_id: int,
-    current_user: CurrentUser = Depends(require_admin_or_above)
+    current_user: CurrentUser = Depends(require_super_admin)
 ):
     """
     Get all tripwires for a camera
-    (Admin+ only)
+    (Super Admin only)
     """
     try:
         db_manager = DatabaseManager()

--- a/backend/core/fts_system.py
+++ b/backend/core/fts_system.py
@@ -81,6 +81,7 @@ class CameraConfig:
     tripwires: List[TripwireConfig]
     resolution: tuple
     fps: int
+    camera_name: Optional[str] = None
 
 @dataclass
 class GlobalTrack:
@@ -179,7 +180,8 @@ def load_camera_configurations() -> List[CameraConfig]:
                 camera_type=db_config.camera_type,
                 tripwires=tripwires,
                 resolution=db_config.resolution,
-                fps=db_config.fps
+                fps=db_config.fps,
+                camera_name=getattr(db_config, 'camera_name', None) or f"Camera {db_config.camera_id}"
             )
             
             cameras.append(camera_config)
@@ -195,7 +197,8 @@ def load_camera_configurations() -> List[CameraConfig]:
                     tripwires=[
                         TripwireConfig(position=0.755551, spacing=0.01, direction="horizontal", name="EntryDetection")],
                     resolution=detected_cam.resolution,
-                    fps=detected_cam.fps
+                    fps=detected_cam.fps,
+                    camera_name=getattr(detected_cam, 'name', f"Camera {detected_cam.camera_id}")
                 )
                 
                 cameras.append(camera_config)

--- a/backend/core/fts_system.py
+++ b/backend/core/fts_system.py
@@ -172,22 +172,22 @@ def load_camera_configurations() -> List[CameraConfig]:
                 )
                 tripwires.append(tripwire)
             
-            # Create FTS camera config with additional fields
+            # Create FTS camera config
             camera_config = CameraConfig(
                 camera_id=db_config.camera_id,
                 gpu_id=db_config.gpu_id,
                 camera_type=db_config.camera_type,
                 tripwires=tripwires,
                 resolution=db_config.resolution,
-                fps=db_config.fps
+                fps=db_config.fps,
+                camera_name=getattr(db_config, 'camera_name', f"Camera {db_config.camera_id}"),
+                ip_address=getattr(db_config, 'ip_address', None),
+                stream_url=getattr(db_config, 'stream_url', None),
+                username=getattr(db_config, 'username', None),
+                password=getattr(db_config, 'password', None),
+                is_active=getattr(db_config, 'is_active', True)
             )
             
-            # Add additional fields that may be needed for camera access
-            camera_config.stream_url = getattr(db_config, 'stream_url', None)
-            camera_config.ip_address = getattr(db_config, 'ip_address', None)
-            camera_config.username = getattr(db_config, 'username', None)
-            camera_config.password = getattr(db_config, 'password', None)
-            camera_config.camera_name = getattr(db_config, 'camera_name', f"Camera {db_config.camera_id}")
             cameras.append(camera_config)
         
         # If no cameras found in database, try to create from detected cameras
@@ -201,16 +201,15 @@ def load_camera_configurations() -> List[CameraConfig]:
                     tripwires=[
                         TripwireConfig(position=0.755551, spacing=0.01, direction="horizontal", name="EntryDetection")],
                     resolution=detected_cam.resolution,
-                    fps=detected_cam.fps
+                    fps=detected_cam.fps,
+                    camera_name=getattr(detected_cam, 'name', f"Camera {detected_cam.camera_id}"),
+                    ip_address=getattr(detected_cam, 'ip_address', None),
+                    stream_url=getattr(detected_cam, 'stream_url', None),
+                    username=getattr(detected_cam, 'username', None),
+                    password=getattr(detected_cam, 'password', None),
+                    is_active=True
                 )
                 
-                # Add detected camera specific fields
-                camera_config.stream_url = detected_cam.stream_url
-                camera_config.ip_address = detected_cam.ip_address
-                camera_config.username = detected_cam.username
-                camera_config.password = detected_cam.password
-                camera_config.camera_name = detected_cam.name
-                camera_config.source = detected_cam.source
                 cameras.append(camera_config)
         
         log_message(f"Loaded {len(cameras)} camera configurations from database")

--- a/backend/db/db_manager.py
+++ b/backend/db/db_manager.py
@@ -201,12 +201,19 @@ class DatabaseManager:
         try:
             session = self.Session()
             
-            # Get the next available camera_id
-            max_camera_id = session.query(func.max(CameraConfig.camera_id)).scalar()
-            next_camera_id = (max_camera_id + 1) if max_camera_id is not None else 1
+            # Use provided camera_id if specified, otherwise get the next available camera_id
+            if 'camera_id' in camera_data and camera_data['camera_id'] is not None:
+                camera_id = camera_data['camera_id']
+                # Check if this camera_id is already taken
+                existing = session.query(CameraConfig).filter(CameraConfig.camera_id == camera_id).first()
+                if existing:
+                    raise ValueError(f"Camera ID {camera_id} already exists")
+            else:
+                max_camera_id = session.query(func.max(CameraConfig.camera_id)).scalar()
+                camera_id = (max_camera_id + 1) if max_camera_id is not None else 0
             
             camera = CameraConfig(
-                camera_id=next_camera_id,
+                camera_id=camera_id,
                 camera_name=camera_data['camera_name'],
                 camera_type=camera_data.get('camera_type', 'general'),
                 ip_address=camera_data.get('ip_address'),

--- a/backend/db/db_models.py
+++ b/backend/db/db_models.py
@@ -100,28 +100,30 @@ class TrackingRecord(Base):
 class CameraConfig(Base):
     __tablename__ = 'camera_configs'
     
+    # Essential fields for LAN camera operation
     id = Column(Integer, primary_key=True, index=True)
-    camera_id = Column(Integer, unique=True, nullable=False)
-    camera_name = Column(String, nullable=True)  # Optional for simplified setup
+    camera_id = Column(Integer, unique=True, nullable=False)  # Used as camera source (0, 1, 2, etc.)
     camera_type = Column(String, default='entry')  # 'entry', 'exit', 'general'
-    ip_address = Column(String, nullable=True)  # Optional for LAN cameras
-    stream_url = Column(String, nullable=True)  # Optional for LAN cameras
-    username = Column(String, nullable=True)  # Optional for LAN cameras
-    password = Column(String, nullable=True)  # Optional for LAN cameras
     resolution_width = Column(Integer, default=1920)
     resolution_height = Column(Integer, default=1080)
     fps = Column(Integer, default=30)
     gpu_id = Column(Integer, default=0)  # GPU assignment for processing
-    status = Column(String, default='active')  # Simplified: 'active', 'inactive'
     is_active = Column(Boolean, default=False)
-    # Optional fields for advanced setups
-    location_description = Column(String, nullable=True)
-    manufacturer = Column(String, nullable=True)
-    model = Column(String, nullable=True)
-    firmware_version = Column(String, nullable=True)
-    onvif_supported = Column(Boolean, default=False)
     created_at = Column(DateTime, default=func.now())
     updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
+    
+    # Optional fields - only needed for network cameras or advanced features
+    camera_name = Column(String, nullable=True)  # Display name (optional)
+    ip_address = Column(String, nullable=True)  # Only for network cameras
+    stream_url = Column(String, nullable=True)  # Only for network cameras
+    username = Column(String, nullable=True)  # Only for authenticated cameras
+    password = Column(String, nullable=True)  # Only for authenticated cameras
+    status = Column(String, default='active')  # Status tracking (optional)
+    location_description = Column(String, nullable=True)  # Human-readable location
+    manufacturer = Column(String, nullable=True)  # Camera manufacturer
+    model = Column(String, nullable=True)  # Camera model
+    firmware_version = Column(String, nullable=True)  # Camera firmware
+    onvif_supported = Column(Boolean, default=False)  # ONVIF support flag
     
     # Relationships
     tripwires = relationship("Tripwire", back_populates="camera", cascade="all, delete-orphan")
@@ -129,16 +131,19 @@ class CameraConfig(Base):
 class Tripwire(Base):
     __tablename__ = 'tripwires'
     
+    # Essential fields for tripwire detection
     id = Column(Integer, primary_key=True, index=True)
     camera_id = Column(Integer, ForeignKey('camera_configs.camera_id'), nullable=False)
     name = Column(String, nullable=False)  # Tripwire name/identifier
     position = Column(Float, nullable=False)  # Position (0.0 to 1.0)
     spacing = Column(Float, default=0.01)  # Spacing for detection
     direction = Column(String, nullable=False)  # 'horizontal', 'vertical'
-    detection_type = Column(String, default='entry')  # Optional: 'entry', 'exit', 'counting'
-    is_active = Column(Boolean, default=True)  # Optional: allow disabling tripwires
     created_at = Column(DateTime, default=func.now())
     updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
+    
+    # Optional fields for advanced features
+    detection_type = Column(String, default='entry')  # 'entry', 'exit', 'counting'
+    is_active = Column(Boolean, default=True)  # Allow disabling tripwires
     
     # Relationships
     camera = relationship("CameraConfig", back_populates="tripwires")

--- a/backend/db/db_models.py
+++ b/backend/db/db_models.py
@@ -102,23 +102,24 @@ class CameraConfig(Base):
     
     id = Column(Integer, primary_key=True, index=True)
     camera_id = Column(Integer, unique=True, nullable=False)
-    camera_name = Column(String, nullable=False)
+    camera_name = Column(String, nullable=True)  # Optional for simplified setup
     camera_type = Column(String, default='entry')  # 'entry', 'exit', 'general'
-    ip_address = Column(String, nullable=True)  # Camera IP address
-    stream_url = Column(String, nullable=True)  # RTSP/HTTP stream URL
-    username = Column(String, nullable=True)  # Camera authentication
-    password = Column(String, nullable=True)  # Camera authentication
+    ip_address = Column(String, nullable=True)  # Optional for LAN cameras
+    stream_url = Column(String, nullable=True)  # Optional for LAN cameras
+    username = Column(String, nullable=True)  # Optional for LAN cameras
+    password = Column(String, nullable=True)  # Optional for LAN cameras
     resolution_width = Column(Integer, default=1920)
     resolution_height = Column(Integer, default=1080)
     fps = Column(Integer, default=30)
     gpu_id = Column(Integer, default=0)  # GPU assignment for processing
-    status = Column(String, default='discovered')  # 'discovered', 'configured', 'active', 'inactive'
+    status = Column(String, default='active')  # Simplified: 'active', 'inactive'
     is_active = Column(Boolean, default=False)
-    location_description = Column(String, nullable=True)  # Human-readable location
-    manufacturer = Column(String, nullable=True)  # Camera manufacturer
-    model = Column(String, nullable=True)  # Camera model
-    firmware_version = Column(String, nullable=True)  # Camera firmware
-    onvif_supported = Column(Boolean, default=False)  # ONVIF support flag
+    # Optional fields for advanced setups
+    location_description = Column(String, nullable=True)
+    manufacturer = Column(String, nullable=True)
+    model = Column(String, nullable=True)
+    firmware_version = Column(String, nullable=True)
+    onvif_supported = Column(Boolean, default=False)
     created_at = Column(DateTime, default=func.now())
     updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
     
@@ -134,8 +135,8 @@ class Tripwire(Base):
     position = Column(Float, nullable=False)  # Position (0.0 to 1.0)
     spacing = Column(Float, default=0.01)  # Spacing for detection
     direction = Column(String, nullable=False)  # 'horizontal', 'vertical'
-    detection_type = Column(String, default='entry')  # 'entry', 'exit', 'counting'
-    is_active = Column(Boolean, default=True)
+    detection_type = Column(String, default='entry')  # Optional: 'entry', 'exit', 'counting'
+    is_active = Column(Boolean, default=True)  # Optional: allow disabling tripwires
     created_at = Column(DateTime, default=func.now())
     updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
     

--- a/backend/utils/camera_config_loader.py
+++ b/backend/utils/camera_config_loader.py
@@ -31,6 +31,8 @@ class CameraConfig:
     tripwires: List[TripwireConfig]
     resolution: tuple
     fps: int
+    # Optional field for admin convenience
+    camera_name: Optional[str] = None
 
 class CameraConfigLoader:
     """
@@ -144,7 +146,8 @@ class CameraConfigLoader:
                 camera_type=db_camera.camera_type,
                 tripwires=tripwires,
                 resolution=(db_camera.resolution_width, db_camera.resolution_height),
-                fps=db_camera.fps
+                fps=db_camera.fps,
+                camera_name=db_camera.camera_name or f"Camera {db_camera.camera_id}"
             )
             
             return camera_config

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -185,14 +185,6 @@ function App() {
               }
             />
             <Route
-              path="/admin/cameras"
-              element={
-                <ProtectedRoute requiredRole={UserRole.ADMIN}>
-                  <CameraManagement />
-                </ProtectedRoute>
-              }
-            />
-            <Route
               path="/admin/monitor"
               element={
                 <ProtectedRoute requiredRole={UserRole.ADMIN}>

--- a/frontend/src/components/layout/DashboardLayout.tsx
+++ b/frontend/src/components/layout/DashboardLayout.tsx
@@ -98,8 +98,7 @@ export const DashboardLayout: React.FC = () => {
       items.push(
         { name: 'Dashboard', href: '/admin', icon: HomeIcon },
         { name: 'Employee Management', href: '/admin/employees', icon: UsersIcon },
-        { name: 'Attendance', href: '/admin/attendance', icon: ClockIcon },
-        { name: 'Camera Management', href: '/admin/cameras', icon: CameraIcon },
+        { name: 'Attendance Dashboard', href: '/admin/attendance', icon: ClockIcon },
         { name: 'Live Monitor', href: '/admin/monitor', icon: CameraIcon },
       );
     } else if (hasRole(user, UserRole.EMPLOYEE)) {

--- a/frontend/src/components/ui/DataTable.tsx
+++ b/frontend/src/components/ui/DataTable.tsx
@@ -49,13 +49,16 @@ export function DataTable<T>({
   const [sortColumn, setSortColumn] = useState<string | null>(null);
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
 
+  // Ensure data is never null/undefined
+  const safeData = data || [];
+
   // Filter and sort data
   const processedData = useMemo(() => {
-    let filtered = data;
+    let filtered = safeData;
 
     // Apply search filter
     if (searchTerm && searchable) {
-      filtered = data.filter(item =>
+      filtered = safeData.filter(item =>
         columns.some(column => {
           const value = item[column.key as keyof T];
           return String(value).toLowerCase().includes(searchTerm.toLowerCase());
@@ -78,7 +81,7 @@ export function DataTable<T>({
     }
 
     return filtered;
-  }, [data, searchTerm, sortColumn, sortDirection, columns, searchable]);
+  }, [safeData, searchTerm, sortColumn, sortDirection, columns, searchable]);
 
   const handleSort = (columnKey: string, sortable?: boolean) => {
     if (!sortable) return;
@@ -208,7 +211,7 @@ export function DataTable<T>({
         <div className="px-6 py-3 bg-gray-50 border-t border-gray-200">
           <div className="flex items-center justify-between">
             <div className="text-sm text-gray-700">
-              Showing {processedData.length} of {data.length} results
+              Showing {processedData.length} of {safeData.length} results
               {searchTerm && ` for "${searchTerm}"`}
             </div>
           </div>

--- a/start_fts_only.py
+++ b/start_fts_only.py
@@ -141,7 +141,7 @@ def check_cameras():
         if cameras:
             print(f"✅ Found {len(cameras)} configured camera(s)")
             for cam in cameras:
-                print(f"   • Camera {cam.camera_id} ({cam.camera_type})")
+                print(f"   • Camera {cam.camera_id}: {cam.camera_name} ({cam.camera_type})")
         else:
             print("⚠️ No cameras configured")
             print("💡 Configure cameras through the web interface first")

--- a/start_fts_only.py
+++ b/start_fts_only.py
@@ -141,7 +141,7 @@ def check_cameras():
         if cameras:
             print(f"✅ Found {len(cameras)} configured camera(s)")
             for cam in cameras:
-                print(f"   • Camera {cam.camera_id}: {cam.camera_name}")
+                print(f"   • Camera {cam.camera_id} ({cam.camera_type})")
         else:
             print("⚠️ No cameras configured")
             print("💡 Configure cameras through the web interface first")

--- a/start_fts_only.py
+++ b/start_fts_only.py
@@ -9,6 +9,7 @@ import sys
 import time
 import signal
 import threading
+import asyncio
 from pathlib import Path
 
 def setup_environment():
@@ -152,9 +153,49 @@ def check_cameras():
         print(f"⚠️ Could not check camera configuration: {e}")
         return True  # Continue anyway
 
+def run_camera_detection():
+    """Run automatic camera detection and configuration"""
+    try:
+        backend_path = Path(__file__).parent / "backend"
+        sys.path.insert(0, str(backend_path))
+        os.chdir(backend_path)
+        
+        from utils.auto_camera_detector import AutoCameraDetector
+        
+        async def detect_cameras():
+            detector = AutoCameraDetector()
+            cameras = await detector.detect_all_cameras()
+            return cameras
+        
+        # Run camera detection
+        cameras = asyncio.run(detect_cameras())
+        
+        if cameras:
+            print(f"✅ Detected and configured {len(cameras)} cameras:")
+            for camera in cameras:
+                print(f"   • Camera {camera.camera_id}: {camera.name}")
+                print(f"     Default tripwire: EntryDetection at position 0.5")
+        else:
+            print("⚠️  No cameras detected")
+            print("💡 Cameras can be added manually through the admin interface")
+        
+    except Exception as e:
+        print(f"❌ Error during camera detection: {e}")
+        print("💡 Cameras can be added manually through the admin interface")
+
 def main():
     print("🎯 Face Recognition System - Face Tracking System Only")
     print("=" * 60)
+    
+    # Parse command line arguments first
+    import argparse
+    parser = argparse.ArgumentParser(description="Start Face Tracking System Only")
+    parser.add_argument("--no-camera-check", action="store_true", 
+                       help="Skip camera configuration check")
+    parser.add_argument("--auto-detect-cameras", action="store_true",
+                       help="Automatically detect and configure cameras before starting FTS")
+    
+    args = parser.parse_args()
     
     # Check requirements
     if not check_requirements():
@@ -162,25 +203,24 @@ def main():
     
     print()
     
+    # Auto-detect cameras if requested
+    if args.auto_detect_cameras:
+        print("🔍 Auto-detecting cameras...")
+        run_camera_detection()
+        print()
+    
     # Check cameras
-    check_cameras()
-    print()
+    if not args.no_camera_check:
+        check_cameras()
+        print()
     
     # Set up environment
     setup_environment()
     print()
     
-    # Parse command line arguments
-    import argparse
-    parser = argparse.ArgumentParser(description="Start Face Tracking System Only")
-    parser.add_argument("--no-camera-check", action="store_true", 
-                       help="Skip camera configuration check")
-    
-    args = parser.parse_args()
-    
-    if not args.no_camera_check:
+    if not args.no_camera_check and not args.auto_detect_cameras:
         print("💡 Note: Make sure cameras are configured in the database")
-        print("   Use the web interface or backend API to configure cameras first")
+        print("   Use --auto-detect-cameras or the web interface to configure cameras")
         print("")
     
     # Start FTS


### PR DESCRIPTION
Implement camera auto-detection with default tripwires, restrict camera configuration to super admins, and fix a DataTable null error.

The DataTable fix resolves a critical frontend crash when camera data is unexpectedly null. Camera configurations were streamlined for LAN environments, and auto-detection was added to simplify initial setup. All camera management is now restricted to super administrators for enhanced security.